### PR TITLE
Use a deploy key for call announcements

### DIFF
--- a/.github/workflows/announce-calls.yml
+++ b/.github/workflows/announce-calls.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.MICROBLOG_DEPLOY_KEY }}
       - name: Configure Git.
         run: |
           git config --global user.name 'farmOS'


### PR DESCRIPTION
The `announce-calls.yml` workflow ran today (https://github.com/farmOS/farmOS-microblog/actions/runs/3486120776), successfully committed to the `main` branch, and pushed it... but that push did not trigger the `publish.yml` workflow to run, so the posts was not tooted/tweeted.

@symbioquine found this, which provides a possible explanation and workaround: https://jahed.dev/2021/04/24/triggering-github-actions-from-commits-by-other-actions/

Tl;dr: use a deploy key.

I have created a keypair, uploaded the pubkey to this repo's deploy keys, and created an organization-wide secret called `MICROBLOG_DEPLOY_KEY` with the private key (org-wide so that we can push to this from other repos as well for announcing new releases etc).

The only change necessary in this repo (I think) is what you see in this commit. Opening this PR to get some other eyes on it for a quick sanity check to make sure I'm not missing anything.