### PR TITLE
Add create-message workflow to further automate the microblog

### DIFF
--- a/.github/workflows/announce-calls.yml
+++ b/.github/workflows/announce-calls.yml
@@ -5,23 +5,25 @@ on:
     - cron: '0 9 8-14 * *'
 
 jobs:
-  announce:
+  build-message:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.MICROBLOG_DEPLOY_KEY }}
-      - name: Configure Git.
-        run: |
-          git config --global user.name 'farmOS'
-          git config --global user.email 'noreply@farmOS.org'
       # We use `date +\%u` below in combination with the schedule cron rules
       # above to ensure these only run on the days they are meant to. 
-      - name: Announce calls
+      - name: Build message
         run: |
           TZ=UTC
           DAY=$(date +\%u)
           case "${DAY}" in
-              3)    git commit --allow-empty -m 'The #farmOS monthly community call is today at 2pm Eastern. All are welcome! https://farmos.org/community/monthly-call/' ;;
+              3)    echo "MESSAGE=The #farmOS monthly community call is today at 2pm Eastern. All are welcome! https://farmos.org/community/monthly-call/" >> $GITHUB_ENV ;;
           esac
-          git push origin main
+    outputs:
+      message: ${{ env.MESSAGE }}
+  announce-call:
+    uses: ./.github/workflows/create-message.yml
+    needs:
+      - build-message
+    if: ${{ needs.build-message.outputs.message }}
+    with:
+      message: ${{ needs.build-message.outputs.message }}
+    secrets: inherit 

--- a/.github/workflows/create-message.yml
+++ b/.github/workflows/create-message.yml
@@ -1,0 +1,35 @@
+name: Create message
+on:
+  workflow_call:
+    inputs:
+      message:
+        type: string
+        required: true
+    secrets:
+      MICROBLOG_DEPLOY_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message to announce'
+        type: string
+        required: true
+
+jobs:
+  create-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Hard-code the repository. This is needed when this workflow is
+          # triggered using workflow_call from other repositories.
+          repository: farmOS/farmOS-microblog
+          ssh-key: ${{ secrets.MICROBLOG_DEPLOY_KEY }}
+      - name: Configure Git.
+        run: |
+          git config --global user.name 'farmOS'
+          git config --global user.email 'noreply@farmOS.org'
+      - name: Commit/push to farmOS-microblog.
+        run: |
+          git commit --allow-empty --cleanup=whitespace -m '${{ inputs.message }}'
+          git push origin main

--- a/.github/workflows/create-message.yml
+++ b/.github/workflows/create-message.yml
@@ -31,5 +31,7 @@ jobs:
           git config --global user.email 'noreply@farmOS.org'
       - name: Commit/push to farmOS-microblog.
         run: |
-          git commit --allow-empty --cleanup=whitespace -m '${{ inputs.message }}'
+          git commit --allow-empty --cleanup=whitespace -F- << MESSAGE
+          ${{ inputs.message }}
+          MESSAGE
           git push origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mastodon
+        if: github.repository == 'farmOS/farmOS-microblog'
         uses: cbrgm/mastodon-github-action@6cffb7d449201bf36a60589de7a76e18ee226043
         with:
           message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Echo message
+        run: echo ${{ github.event.head_commit.message }}
       - name: Mastodon
         if: github.repository == 'farmOS/farmOS-microblog'
         uses: cbrgm/mastodon-github-action@6cffb7d449201bf36a60589de7a76e18ee226043


### PR DESCRIPTION
Adds a `create-message` workflow to make it easier for other repos to automate with microblog

Couple things here:

1. Adds [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) so the `create-message` workflow workflow can be triggered via the Actions UI or via API.
2. Adds [`workflow_call` ](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call) so both this repository and other repositories can delegate to `create-message` as a job in their own workflows. This is pretty neat, there are lots more docs on [Reusing worfklows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow).
3. Updates the existing `announce-calls` workflow to use the new `create-message` workflow