### PR TITLE
Stop announcing weekly dev calls

### DIFF
--- a/.github/workflows/announce-calls.yml
+++ b/.github/workflows/announce-calls.yml
@@ -3,8 +3,6 @@ on:
   schedule:
     # 8th to the 14th of each month at 9am.
     - cron: '0 9 8-14 * *'
-    # Thusdays at 7am.
-    - cron: '0 7 * * 4'
 
 jobs:
   announce:
@@ -25,6 +23,5 @@ jobs:
           DAY=$(date +\%u)
           case "${DAY}" in
               3)    git commit --allow-empty -m 'The #farmOS monthly community call is today at 2pm Eastern. All are welcome! https://farmos.org/community/monthly-call/' ;;
-              4)    git commit --allow-empty -m 'The #farmOS weekly dev call is today at 12pm Eastern. All are welcome! https://meet.jit.si/farmos-dev' ;;
           esac
           git push origin main


### PR DESCRIPTION
We talked about this on the dev call today. The weeks just go by too quickly, and we don't post enough on the microblog currently, so it's just a bunch of dev call announcements.